### PR TITLE
Inherit from ApplicationController

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,4 @@
-class WelcomeController < ActionController::Base
+class WelcomeController < ApplicationController
   def index
   end
 end


### PR DESCRIPTION
The issue was that the default layout wasn't rendered. As a result, application.js wasn't included in the page. In general, you want to inherit from ApplicationController, since you want to build off the basic behavior.